### PR TITLE
Fix Failing Github Actions Tests (#1753)

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-16.04
+    runs-on: ubuntu-20.04
     steps:
     - uses: actions/checkout@v2
     - name: Set up JDK 1.8

--- a/client/src/test/java/org/asynchttpclient/AsyncStreamHandlerTest.java
+++ b/client/src/test/java/org/asynchttpclient/AsyncStreamHandlerTest.java
@@ -436,7 +436,10 @@ public class AsyncStreamHandlerTest extends HttpTest {
 
         final AtomicReference<HttpHeaders> responseHeaders = new AtomicReference<>();
 
+        // Some responses contain the TRACE method, some do not - account for both
+          // FIXME: Actually refactor this test to account for both cases
         final String[] expected = {"GET", "HEAD", "OPTIONS", "POST"};
+        final String[] expectedWithTrace = {"GET", "HEAD", "OPTIONS", "POST", "TRACE"};
         Future<String> f = client.prepareOptions("http://www.apache.org/").execute(new AsyncHandlerAdapter() {
 
           @Override
@@ -455,10 +458,16 @@ public class AsyncStreamHandlerTest extends HttpTest {
         HttpHeaders h = responseHeaders.get();
         assertNotNull(h);
         String[] values = h.get(ALLOW).split(",|, ");
-        assertNotNull(values);
-        assertEquals(values.length, expected.length);
+          assertNotNull(values);
+        // Some responses contain the TRACE method, some do not - account for both
+        assert(values.length == expected.length || values.length == expectedWithTrace.length);
         Arrays.sort(values);
-        assertEquals(values, expected);
+        // Some responses contain the TRACE method, some do not - account for both
+          if(values.length == expected.length) {
+              assertEquals(values, expected);
+          } else {
+              assertEquals(values, expectedWithTrace);
+          }
       }));
   }
 

--- a/client/src/test/java/org/asynchttpclient/channel/MaxTotalConnectionTest.java
+++ b/client/src/test/java/org/asynchttpclient/channel/MaxTotalConnectionTest.java
@@ -69,7 +69,7 @@ public class MaxTotalConnectionTest extends AbstractBasicTest {
 
   @Test(groups = "online")
   public void testMaxTotalConnections() throws Exception {
-    String[] urls = new String[]{"https://google.com", "https://github.com"};
+    String[] urls = new String[]{"https://www.google.com", "https://www.youtube.com"};
 
     final CountDownLatch latch = new CountDownLatch(2);
     final AtomicReference<Throwable> ex = new AtomicReference<>();

--- a/client/src/test/java/org/asynchttpclient/ws/TextMessageTest.java
+++ b/client/src/test/java/org/asynchttpclient/ws/TextMessageTest.java
@@ -16,6 +16,7 @@ import org.asynchttpclient.AsyncHttpClient;
 import org.testng.annotations.Test;
 
 import java.net.UnknownHostException;
+import java.net.ConnectException;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.atomic.AtomicReference;
@@ -70,11 +71,14 @@ public class TextMessageTest extends AbstractBasicWebSocketTest {
     }
   }
 
-  @Test(timeOut = 60000, expectedExceptions = UnknownHostException.class)
+  @Test(timeOut = 60000, expectedExceptions = {UnknownHostException.class, ConnectException.class})
   public void onFailureTest() throws Throwable {
     try (AsyncHttpClient c = asyncHttpClient()) {
       c.prepareGet("ws://abcdefg").execute(new WebSocketUpgradeHandler.Builder().build()).get();
     } catch (ExecutionException e) {
+
+      String expectedMessage = "DNS name not found";
+      assertTrue(e.getCause().toString().contains(expectedMessage));
       throw e.getCause();
     }
   }


### PR DESCRIPTION
* Bump GitHub Actions runner version to Ubuntu 20.04

* AsyncStreamHandlerTest.asyncOptionsTest - Allow for the appearance of the TRACE method in the server's response

* MaxTotalConnectionTest.testMaxTotalConnections - https://github.com --> https://www.youtube.com, https://google.com --> https://www.google.com 

* TextMessageTest.onFailureTest - Refactor logic for more granular testing (accept ConnectException in addition to UnknownHostException, but check for "DNS Name not found" in exception cause)